### PR TITLE
Fix to ensure previous $array in extractAndSet is preserved

### DIFF
--- a/src/ZF/Configuration/ConfigResource.php
+++ b/src/ZF/Configuration/ConfigResource.php
@@ -291,7 +291,9 @@ class ConfigResource
     {
         $key = array_shift($keys);
         if (count($keys)) {
-            $array[$key] = array();
+            if (!isset($array[$key]) || !is_array($array[$key])) {
+                $array[$key] = array();
+            }
             $reference   = &$array[$key];
             $this->extractAndSet($keys, $value, $reference);
             return;

--- a/test/ZFTest/Configuration/ConfigResourceTest.php
+++ b/test/ZFTest/Configuration/ConfigResourceTest.php
@@ -14,6 +14,9 @@ use ZF\Configuration\ConfigResource;
 class ConfigResourceTest extends TestCase
 {
     public $file;
+    /** @var ConfigResource */
+    protected $configResource;
+    protected $writer;
 
     public function setUp()
     {
@@ -67,6 +70,10 @@ class ConfigResourceTest extends TestCase
         $this->assertInternalType('array', $patchValues['foo']['bar']);
         $this->assertArrayHasKey('baz', $patchValues['foo']['bar']);
         $this->assertEquals('value', $patchValues['foo']['bar']['baz']);
+
+        // ensure second call to createNestedKeyValuePair does not destroy original values
+        $this->configResource->createNestedKeyValuePair($patchValues, 'foo.bar.boom', 'value2');
+        $this->assertCount(2, $patchValues['foo']['bar']);
     }
 
     public function testPatchListUpdatesFileWithMergedConfig()


### PR DESCRIPTION
If previous keys are in the passed in array, they are automatically destroyed.  This patch fixes this behavior to ensure previous values are left in tact, and only non-array values will be destroyed, if patching with a nested set.
