### PR TITLE
Re-instates possibility for enabling short array syntax

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -39,7 +39,19 @@ class Module
     {
         return array('factories' => array(
             'ZF\Configuration\ConfigWriter' => function ($services) {
+                $useShortArray = false;
+                if ($services->has('Config')) {
+                    $config = $services->get('Config');
+                    if (isset($config['zf-configuration']['enable_short_array'])) {
+                        $useShortArray = (bool) $config['zf-configuration']['enable_short_array'];
+                    }
+                }
+
                 $writer = new PhpArray();
+                if ($useShortArray && version_compare(PHP_VERSION, '5.4.0', '>=')) {
+                    $writer->setUseBracketArraySyntax(true);
+                }
+
                 return $writer;
             },
             'ZF\Configuration\ConfigResource' => function ($services) {

--- a/README.md
+++ b/README.md
@@ -52,8 +52,14 @@ The top-level configuration key for user configuration of this module is `zf-con
 ```php
 'zf-configuration' => array(
     'config_file' => 'config/autoload/development.php',
+    'enable_short_array' => false,
 ),
 ```
+
+#### Key: `enable_short_array`
+
+Set this value to a boolean `true` if you want to use PHP 5.4's square bracket (aka "short") array
+syntax.
 
 ZF2 Events
 ----------

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -7,5 +7,10 @@
 return array(
     'zf-configuration' => array(
         'config_file' => 'config/autoload/development.php',
+        /* set the following flag if you wish to use PHP 5.4 short array syntax
+         * in configuration files manipulated by the ConfigWriter
+         *
+         * 'enable_short_array' => true,
+         */
     ),
 );


### PR DESCRIPTION
- Re-adds the "enable_short_array" config option, as well as the logic in the
  ConfigWriter factory for detecting and enabling it in the writer.
- Documents the configuration value.
