### PR TITLE
Enable short array syntax by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ The top-level configuration key for user configuration of this module is `zf-con
 ```php
 'zf-configuration' => [
     'config_file' => 'config/autoload/development.php',
-    'enable_short_array' => false,
+    'enable_short_array' => true,
 ],
 ```
 
 #### Key: `enable_short_array`
 
-Set this value to a boolean `true` if you want to use PHP 5.4's square bracket (aka "short") array
+Set this value to a boolean `false` if you don't want to use square bracket (aka "short") array
 syntax.
 
 ZF2 Events

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -9,11 +9,7 @@ namespace ZF\Configuration;
 return [
     'zf-configuration' => [
         'config_file' => 'config/autoload/development.php',
-        /* set the following flag if you wish to use short array syntax
-         * in configuration files manipulated by the ConfigWriter:
-         *
-         * 'enable_short_array' => true,
-         */
+        'enable_short_array' => true,
     ],
     'service_manager' => [
         'factories' => [
@@ -21,6 +17,6 @@ return [
             ConfigResourceFactory::class => Factory\ResourceFactoryFactory::class,
             ConfigWriter::class          => Factory\ConfigWriterFactory::class,
             ModuleUtils::class           => Factory\ModuleUtilsFactory::class,
-        ]
+        ],
     ],
 ];

--- a/src/Factory/ConfigWriterFactory.php
+++ b/src/Factory/ConfigWriterFactory.php
@@ -29,7 +29,7 @@ class ConfigWriterFactory
     }
 
     /**
-     * Discover the enable_short_array flag from configuration, if present.
+     * Discover the enable_short_array flag from configuration.
      *
      * @param ContainerInterface $container
      * @return bool
@@ -41,10 +41,6 @@ class ConfigWriterFactory
         }
 
         $config = $container->get('config');
-
-        if (! isset($config['zf-configuration']['enable_short_array'])) {
-            return false;
-        }
 
         return (bool) $config['zf-configuration']['enable_short_array'];
     }


### PR DESCRIPTION
As we support php >= 5.6, we can enable short array syntax in configuration by default.