### PR TITLE
New configuration option: class_name_scalars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea/
 vendor/
 phpunit.xml

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The top-level configuration key for user configuration of this module is `zf-con
 'zf-configuration' => [
     'config_file' => 'config/autoload/development.php',
     'enable_short_array' => false,
+    'class_name_scalars' => false,
 ],
 ```
 
@@ -70,6 +71,10 @@ The top-level configuration key for user configuration of this module is `zf-con
 
 Set this value to a boolean `true` if you want to use PHP 5.4's square bracket (aka "short") array
 syntax.
+
+#### Key: `class_name_scalars`
+
+Set this value to a boolean `true` if you want to use PHP 5.5's class name scalars (`::class` notation).
 
 ZF2 Events
 ----------

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8 || ^5.0",
-        "squizlabs/php_codesniffer": "^2.3.1"
+        "squizlabs/php_codesniffer": "^2.3.1",
+        "zendframework/zend-servicemanager": "^2.7.6 || ^3.1.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,8 @@
         "zendframework/zend-stdlib": "^2.7.7 || ^3.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8 || ^5.0",
-        "squizlabs/php_codesniffer": "^2.3.1",
+        "phpunit/phpunit": "^4.8 || ^5.5",
+        "squizlabs/php_codesniffer": "^2.6.2",
         "zendframework/zend-servicemanager": "^2.7.6 || ^3.1.1"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "50236fef20dbbead0cd8593e57dea5d2",
-    "content-hash": "3c48ef6554cc4c1bde24ec735c01c26f",
+    "hash": "faca7b2c39f9a7b5d80f52b13a242a7c",
+    "content-hash": "efabaf35dbd8748a46ba9c759681f9ef",
     "packages": [
         {
             "name": "zendframework/zend-config",
@@ -556,16 +556,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "900370c81280cc0d942ffbc5912d80464eaee7e9"
+                "reference": "5f3f7e736d6319d5f1fc402aff8b026da26709a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/900370c81280cc0d942ffbc5912d80464eaee7e9",
-                "reference": "900370c81280cc0d942ffbc5912d80464eaee7e9",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/5f3f7e736d6319d5f1fc402aff8b026da26709a3",
+                "reference": "5f3f7e736d6319d5f1fc402aff8b026da26709a3",
                 "shasum": ""
             },
             "require": {
@@ -574,7 +574,7 @@
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-token-stream": "^1.4.2",
                 "sebastian/code-unit-reverse-lookup": "~1.0",
-                "sebastian/environment": "^1.3.2",
+                "sebastian/environment": "^1.3.2 || ^2.0",
                 "sebastian/version": "~1.0|~2.0"
             },
             "require-dev": {
@@ -615,7 +615,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-06-03 05:03:56"
+            "time": "2016-07-26 14:39:29"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -800,16 +800,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.4.6",
+            "version": "5.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "2f1fc94b77ea6418bd6a06c64a1dac0645fbce59"
+                "reference": "c7b3e1dcc1d183f26d5ba282881fe65c2cbb5b2b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2f1fc94b77ea6418bd6a06c64a1dac0645fbce59",
-                "reference": "2f1fc94b77ea6418bd6a06c64a1dac0645fbce59",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c7b3e1dcc1d183f26d5ba282881fe65c2cbb5b2b",
+                "reference": "c7b3e1dcc1d183f26d5ba282881fe65c2cbb5b2b",
                 "shasum": ""
             },
             "require": {
@@ -821,7 +821,7 @@
                 "myclabs/deep-copy": "~1.3",
                 "php": "^5.6 || ^7.0",
                 "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "^4.0",
+                "phpunit/php-code-coverage": "^4.0.1",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
@@ -848,7 +848,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.4.x-dev"
+                    "dev-master": "5.5.x-dev"
                 }
             },
             "autoload": {
@@ -874,7 +874,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-06-16 06:01:15"
+            "time": "2016-08-05 04:49:02"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1450,16 +1450,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.6.1",
+            "version": "2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "fb72ed32f8418db5e7770be1653e62e0d6f5dd3d"
+                "reference": "4edb770cb853def6e60c93abb088ad5ac2010c83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/fb72ed32f8418db5e7770be1653e62e0d6f5dd3d",
-                "reference": "fb72ed32f8418db5e7770be1653e62e0d6f5dd3d",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4edb770cb853def6e60c93abb088ad5ac2010c83",
+                "reference": "4edb770cb853def6e60c93abb088ad5ac2010c83",
                 "shasum": ""
             },
             "require": {
@@ -1524,20 +1524,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-05-30 22:24:32"
+            "time": "2016-07-13 23:29:13"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.1.2",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "2884c26ce4c1d61aebf423a8b912950fe7c764de"
+                "reference": "1819adf2066880c7967df7180f4f662b6f0567ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/2884c26ce4c1d61aebf423a8b912950fe7c764de",
-                "reference": "2884c26ce4c1d61aebf423a8b912950fe7c764de",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/1819adf2066880c7967df7180f4f662b6f0567ac",
+                "reference": "1819adf2066880c7967df7180f4f662b6f0567ac",
                 "shasum": ""
             },
             "require": {
@@ -1573,32 +1573,33 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-07-17 14:02:08"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde"
+                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde",
-                "reference": "30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
+                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3|^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6"
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.2-dev"
                 }
             },
             "autoload": {
@@ -1622,7 +1623,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2015-08-24 13:29:44"
+            "time": "2016-08-09 15:02:57"
         },
         {
             "name": "zendframework/zend-servicemanager",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d1a2f3ed02ac84ba3d2bb4c164468321",
-    "content-hash": "78adbef39009ff0996aa29d27530f93b",
+    "hash": "50236fef20dbbead0cd8593e57dea5d2",
+    "content-hash": "3c48ef6554cc4c1bde24ec735c01c26f",
     "packages": [
         {
             "name": "zendframework/zend-config",
@@ -223,6 +223,33 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "container-interop/container-interop",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/fc08354828f8fd3245f77a66b9e23a6bca48297e",
+                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "time": "2014-12-30 15:22:37"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.0.5",
@@ -1596,6 +1623,61 @@
                 "validate"
             ],
             "time": "2015-08-24 13:29:44"
+        },
+        {
+            "name": "zendframework/zend-servicemanager",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-servicemanager.git",
+                "reference": "f701b0d322741b0c8d8ca1288f249a49438029cd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/f701b0d322741b0c8d8ca1288f249a49438029cd",
+                "reference": "f701b0d322741b0c8d8ca1288f249a49438029cd",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "~1.0",
+                "php": "^5.5 || ^7.0"
+            },
+            "provide": {
+                "container-interop/container-interop-implementation": "^1.1"
+            },
+            "require-dev": {
+                "ocramius/proxy-manager": "^1.0 || ^2.0",
+                "phpbench/phpbench": "^0.10.0",
+                "phpunit/phpunit": "^4.6 || ^5.2.10",
+                "squizlabs/php_codesniffer": "^2.5.1"
+            },
+            "suggest": {
+                "ocramius/proxy-manager": "ProxyManager 1.* to handle lazy initialization of services",
+                "zendframework/zend-stdlib": "zend-stdlib ^2.5 if you wish to use the MergeReplaceKey or MergeRemoveKey features in Config instances"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev",
+                    "dev-develop": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\ServiceManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-servicemanager",
+            "keywords": [
+                "service-manager",
+                "servicemanager",
+                "zf"
+            ],
+            "time": "2016-07-15 14:59:51"
         }
     ],
     "aliases": [],

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -23,6 +23,6 @@ return [
             ConfigResourceFactory::class => Factory\ResourceFactoryFactory::class,
             ConfigWriter::class          => Factory\ConfigWriterFactory::class,
             ModuleUtils::class           => Factory\ModuleUtilsFactory::class,
-        ]
+        ],
     ],
 ];

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -9,11 +9,9 @@ namespace ZF\Configuration;
 return [
     'zf-configuration' => [
         'config_file' => 'config/autoload/development.php',
-        /* set the following flag if you wish to use short array syntax
-         * in configuration files manipulated by the ConfigWriter:
-         *
-         * 'enable_short_array' => true,
-         */
+        // set the following flag if you wish to use short array syntax
+        // in configuration files manipulated by the ConfigWriter:
+        // 'enable_short_array' => true,
 
         // class_name_scalars defines whether configuration files
         // manipulated by the ConfigWriter should use ::class notation

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -14,6 +14,10 @@ return [
          *
          * 'enable_short_array' => true,
          */
+
+        // class_name_scalars defines whether configuration files
+        // manipulated by the ConfigWriter should use ::class notation
+        // 'class_name_scalars' => true,
     ],
     'service_manager' => [
         'factories' => [

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,6 +9,12 @@
     <!-- inherit rules from: -->
     <rule ref="PSR2"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+    <rule ref="Generic.Formatting.SpaceAfterNot"/>
+    <rule ref="Squiz.WhiteSpace.OperatorSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
         <properties>
             <property name="ignoreBlankLines" value="false"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <phpunit bootstrap="./vendor/autoload.php" colors="true">
     <testsuites>
         <testsuite name="ZFConfiguration Module Tests">

--- a/src/ConfigResource.php
+++ b/src/ConfigResource.php
@@ -152,7 +152,7 @@ class ConfigResource
      *
      * Flattens nested configuration to dot-separated key/value pairs and returns them.
      *
-     * @param  array $params
+     * @param  bool $tree
      * @return array
      */
     public function fetch($tree = false)

--- a/src/ConfigResource.php
+++ b/src/ConfigResource.php
@@ -68,7 +68,7 @@ class ConfigResource
         }
 
         // Update configuration from dot-separated key/value pairs
-        if (!$tree) {
+        if (! $tree) {
             $patchValues = [];
             foreach ($data as $key => $value) {
                 $this->createNestedKeyValuePair($patchValues, $key, $value);
@@ -81,7 +81,7 @@ class ConfigResource
         $localConfig = [];
         if (file_exists($this->fileName)) {
             $localConfig = include $this->fileName;
-            if (!is_array($localConfig)) {
+            if (! is_array($localConfig)) {
                 $localConfig = [];
             }
         }
@@ -111,7 +111,7 @@ class ConfigResource
         $config = [];
         if (file_exists($this->fileName)) {
             $config = include $this->fileName;
-            if (!is_array($config)) {
+            if (! is_array($config)) {
                 $config = [];
             }
         }
@@ -183,7 +183,7 @@ class ConfigResource
      */
     public function replaceKey($keys, $value, array $config)
     {
-        if (!is_array($keys)) {
+        if (! is_array($keys)) {
             $keys = explode('.', $keys);
         }
 
@@ -192,15 +192,15 @@ class ConfigResource
         $haveKeys = (count($keys) > 0) ? true : false;
 
         // If no more keys, overwrite and return
-        if (!$haveKeys) {
+        if (! $haveKeys) {
             $config[$key] = $value;
             return $config;
         }
 
         // If key does not exist, or the current value is not an associative
         // array, create nested set and return
-        if (!isset($config[$key])
-            || !ArrayUtils::isHashTable($config[$key])
+        if (! isset($config[$key])
+            || ! ArrayUtils::isHashTable($config[$key])
         ) {
             $config[$key] = $this->replaceKey($keys, $value, []);
             return $config;
@@ -225,12 +225,12 @@ class ConfigResource
         $config = [];
         if (file_exists($this->fileName)) {
             $config = include $this->fileName;
-            if (!is_array($config)) {
+            if (! is_array($config)) {
                 $config = [];
             }
         }
 
-        if (!is_array($keys)) {
+        if (! is_array($keys)) {
             $keys = explode('.', $keys);
         }
 
@@ -282,7 +282,7 @@ class ConfigResource
      */
     public function createNestedKeyValuePair(&$patchValues, $key, $value)
     {
-        if (!is_array($patchValues)) {
+        if (! is_array($patchValues)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects the $patchValues argument to be an array; received %s',
                 __METHOD__,
@@ -304,7 +304,7 @@ class ConfigResource
     {
         $key = array_shift($keys);
         if (count($keys)) {
-            if (!isset($array[$key]) || !is_array($array[$key])) {
+            if (! isset($array[$key]) || ! is_array($array[$key])) {
                 $array[$key] = [];
             }
             $reference   = &$array[$key];
@@ -323,7 +323,7 @@ class ConfigResource
     protected function deleteByKey(&$array, array $keys)
     {
         $key = array_shift($keys);
-        if (!is_array($array) || !array_key_exists($key, $array)) {
+        if (! is_array($array) || ! array_key_exists($key, $array)) {
             return;
         }
 
@@ -341,7 +341,7 @@ class ConfigResource
      */
     protected function invalidateCache($filename)
     {
-        if (!$this->opcacheEnabled) {
+        if (! $this->opcacheEnabled) {
             return;
         }
 

--- a/src/Factory/ConfigResourceFactory.php
+++ b/src/Factory/ConfigResourceFactory.php
@@ -31,7 +31,7 @@ class ConfigResourceFactory
         return new ConfigResource(
             $config,
             $this->discoverConfigFile($config),
-            $container>get(ConfigWriter::class)
+            $container->get(ConfigWriter::class)
         );
     }
 

--- a/src/Factory/ConfigWriterFactory.php
+++ b/src/Factory/ConfigWriterFactory.php
@@ -21,20 +21,25 @@ class ConfigWriterFactory
     {
         $writer = new PhpArray();
 
-        if ($this->discoverEnableShortArrayFlag($container)) {
+        if ($this->discoverConfigFlag($container, 'enable_short_array')) {
             $writer->setUseBracketArraySyntax(true);
+        }
+
+        if ($this->discoverConfigFlag($container, 'class_name_scalars')) {
+            $writer->setUseClassNameScalars(true);
         }
 
         return $writer;
     }
 
     /**
-     * Discover the enable_short_array flag from configuration, if present.
+     * Discover the $key flag from configuration, if present.
      *
      * @param ContainerInterface $container
+     * @param string $key
      * @return bool
      */
-    private function discoverEnableShortArrayFlag(ContainerInterface $container)
+    private function discoverConfigFlag(ContainerInterface $container, $key)
     {
         if (! $container->has('config')) {
             return false;
@@ -42,10 +47,10 @@ class ConfigWriterFactory
 
         $config = $container->get('config');
 
-        if (! isset($config['zf-configuration']['enable_short_array'])) {
+        if (! isset($config['zf-configuration'][$key])) {
             return false;
         }
 
-        return (bool) $config['zf-configuration']['enable_short_array'];
+        return (bool) $config['zf-configuration'][$key];
     }
 }

--- a/src/ModuleUtils.php
+++ b/src/ModuleUtils.php
@@ -83,7 +83,7 @@ class ModuleUtils
      */
     protected function validateModule($moduleName)
     {
-        if (!array_key_exists($moduleName, $this->modules)) {
+        if (! array_key_exists($moduleName, $this->modules)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'The module specified, "%s", does not exist; cannot retrieve module data',
                 $moduleName
@@ -150,7 +150,7 @@ class ModuleUtils
      */
     protected function recurseTree($path)
     {
-        if (!is_dir($path)) {
+        if (! is_dir($path)) {
             return false;
         }
 

--- a/test/ConfigResourceFactoryTest.php
+++ b/test/ConfigResourceFactoryTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Configuration;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Prophecy\Prophecy\ProphecyInterface;
+use Zend\Config\Writer\WriterInterface;
+use ZF\Configuration\ConfigResource;
+use ZF\Configuration\ConfigWriter;
+use ZF\Configuration\Factory\ConfigResourceFactory;
+
+class ConfigResourceFactoryTest extends TestCase
+{
+    /**
+     * @var ContainerInterface|ProphecyInterface
+     */
+    private $container;
+
+    /**
+     * @var ConfigResourceFactory
+     */
+    private $factory;
+
+    /**
+     * @var WriterInterface
+     */
+    private $writer;
+
+    protected function setUp()
+    {
+        $this->writer = $this->prophesize(WriterInterface::class)->reveal();
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->container->get(ConfigWriter::class)->willReturn($this->writer);
+        $this->factory = new ConfigResourceFactory();
+    }
+
+    public function testReturnsInstanceOfConfigResource()
+    {
+        $this->container->has('config')->willReturn(false);
+
+        $factory = $this->factory;
+        $configResource = $factory($this->container->reveal());
+
+        $this->assertInstanceOf(ConfigResource::class, $configResource);
+    }
+
+    public function testDefaultAttributesValues()
+    {
+        $this->container->has('config')->willReturn(false);
+
+        $factory = $this->factory;
+
+        /** @var ConfigResource $configResource */
+        $configResource = $factory($this->container->reveal());
+
+        $this->assertAttributeSame([], 'config', $configResource);
+        $this->assertAttributeSame('config/autoload/development.php', 'fileName', $configResource);
+        $this->assertAttributeSame($this->writer, 'writer', $configResource);
+    }
+
+    public function testCustomConfigFileIsSet()
+    {
+        $configFile = uniqid('config_file');
+        $config = [
+            'zf-configuration' => [
+                'config_file' => $configFile,
+            ],
+        ];
+
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+
+        $factory = $this->factory;
+
+        /** @var ConfigResource $configResource */
+        $configResource = $factory($this->container->reveal());
+
+        $this->assertAttributeSame($config, 'config', $configResource);
+        $this->assertAttributeSame($configFile, 'fileName', $configResource);
+    }
+
+    public function testCustomConfigurationIsPassToConfigResource()
+    {
+        $config = [
+            'custom-configuration' => [
+                'foo' => 'bar',
+            ],
+        ];
+
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+
+        $factory = $this->factory;
+
+        /** @var ConfigResource $configResource */
+        $configResource = $factory($this->container->reveal());
+
+        $this->assertAttributeSame($config, 'config', $configResource);
+    }
+}

--- a/test/ConfigResourceTest.php
+++ b/test/ConfigResourceTest.php
@@ -42,7 +42,7 @@ class ConfigResourceTest extends TestCase
 
     public function arrayIntersectAssocRecursive($array1, $array2)
     {
-        if (!is_array($array1) || !is_array($array2)) {
+        if (! is_array($array1) || ! is_array($array2)) {
             if ($array1 === $array2) {
                 return $array1;
             }

--- a/test/ConfigResourceTest.php
+++ b/test/ConfigResourceTest.php
@@ -200,30 +200,30 @@ class ConfigResourceTest extends TestCase
             'overwrite-hash'          => ['sub', 'updated', ['sub' => 'updated']],
             'nested-scalar'           => ['sub.level', 'updated', [
                 'sub' => [
-                    'level' => 'updated'
-                ]
+                    'level' => 'updated',
+                ],
             ]],
             'nested-list'             => ['sub.list', ['three', 'four'], [
                 'sub' => [
-                    'list' => ['three', 'four']
-                ]
+                    'list' => ['three', 'four'],
+                ],
             ]],
             'nested-hash'             => ['sub.hash.two', 'updated', [
                 'sub' => [
                     'hash' => [
-                        'two' => 'updated'
-                    ]
-                ]
+                        'two' => 'updated',
+                    ],
+                ],
             ]],
             'overwrite-nested-null'   => ['sub.null', 'updated', [
                 'sub' => [
-                    'null' => 'updated'
-                ]
+                    'null' => 'updated',
+                ],
             ]],
             'overwrite-nested-object' => ['sub.object', 'updated', [
                 'sub' => [
-                    'object' => 'updated'
-                ]
+                    'object' => 'updated',
+                ],
             ]],
         ];
     }

--- a/test/ConfigWriterFactoryTest.php
+++ b/test/ConfigWriterFactoryTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Configuration;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Prophecy\Prophecy\ProphecyInterface;
+use Zend\Config\Writer\PhpArray;
+use ZF\Configuration\Factory\ConfigWriterFactory;
+
+class ConfigWriterFactoryTest extends TestCase
+{
+    /**
+     * @var ContainerInterface|ProphecyInterface
+     */
+    private $container;
+
+    /**
+     * @var ConfigWriterFactory
+     */
+    private $factory;
+
+    protected function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->factory = new ConfigWriterFactory();
+    }
+
+    public function testReturnsInstanceOfPhpArrayWriter()
+    {
+        $factory = $this->factory;
+        $configWriter = $factory($this->container->reveal());
+
+        $this->assertInstanceOf(PhpArray::class, $configWriter);
+    }
+
+    public function testDefaultFlagsValues()
+    {
+        $factory = $this->factory;
+
+        /** @var PhpArray $configWriter */
+        $configWriter = $factory($this->container->reveal());
+
+        $this->assertAttributeSame(false, 'useBracketArraySyntax', $configWriter);
+        $this->assertFalse($configWriter->getUseClassNameScalars());
+    }
+
+    public function testEnableShortArrayFlagIsSet()
+    {
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn([
+            'zf-configuration' => [
+                'enable_short_array' => true,
+            ],
+        ]);
+
+        $factory = $this->factory;
+
+        /** @var PhpArray $configWriter */
+        $configWriter = $factory($this->container->reveal());
+
+        $this->assertAttributeSame(true, 'useBracketArraySyntax', $configWriter);
+    }
+
+    public function testClassNameScalarsFlagIsSet()
+    {
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn([
+            'zf-configuration' => [
+                'class_name_scalars' => true,
+            ],
+        ]);
+
+        $factory = $this->factory;
+
+        /** @var PhpArray $configWriter */
+        $configWriter = $factory($this->container->reveal());
+
+        $this->assertTrue($configWriter->getUseClassNameScalars());
+    }
+}


### PR DESCRIPTION
@weierophinney as we discussed, added new configuration option: `class_name_scalars`.

By default is set to `false`.

When it is set to `true` ConfigWriter will use `::class` notation on writing to configuration files.

In this PR also improvement some parts of the repository:
- Updated CS rules + CS fixes.
- Fixed invalid PHPDocs.
- Fixed syntax error in `ConfigResourceFactory` + tests.
- Added trailing comma in arrays.