### PR TITLE
Hotfix #21 - patchKey merge configuration instead of override

### DIFF
--- a/src/ConfigResource.php
+++ b/src/ConfigResource.php
@@ -107,25 +107,9 @@ class ConfigResource
      */
     public function patchKey($key, $value)
     {
-        // Get local config file
-        $config = [];
-        if (file_exists($this->fileName)) {
-            $config = include $this->fileName;
-            if (! is_array($config)) {
-                $config = [];
-            }
-        }
-        $config = $this->replaceKey($key, $value, $config);
+        $this->patch([$key => $value]);
 
-        // Write to configuration file
-        $this->writer->toFile($this->fileName, $config);
-        $this->invalidateCache($this->fileName);
-
-        // Reseed configuration
-        $this->config = $config;
-
-        // Return written values
-        return $config;
+        return $this->config;
     }
 
     /**

--- a/src/ConfigResource.php
+++ b/src/ConfigResource.php
@@ -55,6 +55,7 @@ class ConfigResource
      * Expects data to be in the form of key/value pairs
      *
      * @param  array|stdClass|Traversable $data
+     * @param  bool $tree
      * @return array
      */
     public function patch($data, $tree = false)

--- a/test/ConfigResourceTest.php
+++ b/test/ConfigResourceTest.php
@@ -9,6 +9,7 @@ namespace ZFTest\Configuration;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Zend\Config\Writer\PhpArray;
+use Zend\Stdlib\ArrayUtils;
 use ZF\Configuration\ConfigResource;
 
 class ConfigResourceTest extends TestCase
@@ -401,5 +402,128 @@ class ConfigResourceTest extends TestCase
         // Verify the file contains what we expect
         $test = include $this->file;
         $this->assertEquals($expected, $test);
+    }
+
+    public function patchKey()
+    {
+        return [
+            'scalar-top-level' => [
+                'top',
+                'updated',
+                ['top' => 'updated']
+            ],
+
+            'overwrite-hash' => [
+                'sub',
+                'updated',
+                ['sub' => 'updated'],
+            ],
+
+            'nested-scalar' => [
+                'sub.level',
+                'updated',
+                [
+                    'sub' => [
+                        'level' => 'updated',
+                    ],
+                ],
+            ],
+            'nested-list' => [
+                'sub.list',
+                ['three', 'four'],
+                [
+                    'sub' => [
+                        'list' => ['three', 'four'],
+                    ],
+                ],
+            ],
+            'nested-hash' => [
+                'sub.hash.two',
+                'updated',
+                [
+                    'sub' => [
+                        'hash' => [
+                            'two' => 'updated',
+                        ],
+                    ],
+                ],
+            ],
+            'overwrite-nested-null' => [
+                'sub.null',
+                'updated',
+                [
+                    'sub' => [
+                        'null' => 'updated',
+                    ],
+                ],
+            ],
+            'overwrite-nested-object' => [
+                'sub.object',
+                'updated',
+                [
+                    'sub' => [
+                        'object' => 'updated',
+                    ],
+                ],
+            ],
+            'merge-nested' => [
+                'sub.hash',
+                [
+                    'two' => 'two-updated',
+                    'three' => 'three-updated',
+                ],
+                [
+                    'sub' => [
+                        'hash' => [
+                            'one' => 1,
+                            'two' => 'two-updated',
+                            'three' => 'three-updated',
+                        ],
+                    ],
+                ],
+            ],
+            'add-new' => [
+                'sub',
+                ['new' => 'added'],
+                [
+                    'sub' => [
+                        'new' => 'added',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider patchKey
+     *
+     * @param string $key
+     * @param mixed $value
+     * @param mixed $expected
+     */
+    public function testPatchKey($key, $value, $expected)
+    {
+        $config = [
+            'top' => 'level',
+            'sub' => [
+                'level' => 2,
+                'list' => [
+                    'one',
+                    'two',
+                ],
+                'hash' => [
+                    'one' => 1,
+                    'two' => 2,
+                ],
+                'null' => null,
+                'object' => stdClass::class,
+            ],
+        ];
+        $writer = new PhpArray();
+        $writer->toFile($this->file, $config);
+
+        $updated = $this->configResource->patchKey($key, $value);
+        $expected = ArrayUtils::merge($config, $expected);
+        $this->assertEquals($expected, $updated);
     }
 }

--- a/test/ConfigResourceTest.php
+++ b/test/ConfigResourceTest.php
@@ -87,6 +87,8 @@ class ConfigResourceTest extends TestCase
             ],
             'baz' => 'not what you think',
         ];
+        $writer = new PhpArray();
+        $writer->toFile($this->file, $config);
         $configResource = new ConfigResource($config, $this->file, $this->writer);
 
         $patch = [
@@ -98,8 +100,10 @@ class ConfigResourceTest extends TestCase
         $this->assertEquals($patch, $response);
 
         $expected = [
+            'foo' => 'bar',
             'bar' => [
                 'baz' => 'UPDATED',
+                'bat' => 'bogus',
             ],
             'baz' => 'what you think',
         ];


### PR DESCRIPTION
Method `patchKey` was not tested at all. It should merge configuration instead of override.
To override configuration method `replaceKey` should be used instead.

Fixes #21 

/cc @TomHAnderson @kusmierz