### PR TITLE
Revert backwards-incompatible changes

### DIFF
--- a/src/ConfigResource.php
+++ b/src/ConfigResource.php
@@ -110,9 +110,25 @@ class ConfigResource
      */
     public function patchKey($key, $value)
     {
-        $this->patch([$key => $value]);
+        // Get local config file
+        $config = [];
+        if (file_exists($this->fileName)) {
+            $config = include $this->fileName;
+            if (! is_array($config)) {
+                $config = [];
+            }
+        }
+        $config = $this->replaceKey($key, $value, $config);
 
-        return $this->config;
+        // Write to configuration file
+        $this->writer->toFile($this->fileName, $config);
+        $this->invalidateCache($this->fileName);
+
+        // Reseed configuration
+        $this->config = $config;
+
+        // Return written values
+        return $config;
     }
 
     /**

--- a/test/ConfigResourceTest.php
+++ b/test/ConfigResourceTest.php
@@ -9,7 +9,6 @@ namespace ZFTest\Configuration;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Zend\Config\Writer\PhpArray;
-use Zend\Stdlib\ArrayUtils;
 use ZF\Configuration\ConfigResource;
 
 class ConfigResourceTest extends TestCase
@@ -87,8 +86,6 @@ class ConfigResourceTest extends TestCase
             ],
             'baz' => 'not what you think',
         ];
-        $writer = new PhpArray();
-        $writer->toFile($this->file, $config);
         $configResource = new ConfigResource($config, $this->file, $this->writer);
 
         $patch = [
@@ -100,10 +97,8 @@ class ConfigResourceTest extends TestCase
         $this->assertEquals($patch, $response);
 
         $expected = [
-            'foo' => 'bar',
             'bar' => [
                 'baz' => 'UPDATED',
-                'bat' => 'bogus',
             ],
             'baz' => 'what you think',
         ];
@@ -406,128 +401,5 @@ class ConfigResourceTest extends TestCase
         // Verify the file contains what we expect
         $test = include $this->file;
         $this->assertEquals($expected, $test);
-    }
-
-    public function patchKey()
-    {
-        return [
-            'scalar-top-level' => [
-                'top',
-                'updated',
-                ['top' => 'updated']
-            ],
-
-            'overwrite-hash' => [
-                'sub',
-                'updated',
-                ['sub' => 'updated'],
-            ],
-
-            'nested-scalar' => [
-                'sub.level',
-                'updated',
-                [
-                    'sub' => [
-                        'level' => 'updated',
-                    ],
-                ],
-            ],
-            'nested-list' => [
-                'sub.list',
-                ['three', 'four'],
-                [
-                    'sub' => [
-                        'list' => ['three', 'four'],
-                    ],
-                ],
-            ],
-            'nested-hash' => [
-                'sub.hash.two',
-                'updated',
-                [
-                    'sub' => [
-                        'hash' => [
-                            'two' => 'updated',
-                        ],
-                    ],
-                ],
-            ],
-            'overwrite-nested-null' => [
-                'sub.null',
-                'updated',
-                [
-                    'sub' => [
-                        'null' => 'updated',
-                    ],
-                ],
-            ],
-            'overwrite-nested-object' => [
-                'sub.object',
-                'updated',
-                [
-                    'sub' => [
-                        'object' => 'updated',
-                    ],
-                ],
-            ],
-            'merge-nested' => [
-                'sub.hash',
-                [
-                    'two' => 'two-updated',
-                    'three' => 'three-updated',
-                ],
-                [
-                    'sub' => [
-                        'hash' => [
-                            'one' => 1,
-                            'two' => 'two-updated',
-                            'three' => 'three-updated',
-                        ],
-                    ],
-                ],
-            ],
-            'add-new' => [
-                'sub',
-                ['new' => 'added'],
-                [
-                    'sub' => [
-                        'new' => 'added',
-                    ],
-                ],
-            ],
-        ];
-    }
-
-    /**
-     * @dataProvider patchKey
-     *
-     * @param string $key
-     * @param mixed $value
-     * @param mixed $expected
-     */
-    public function testPatchKey($key, $value, $expected)
-    {
-        $config = [
-            'top' => 'level',
-            'sub' => [
-                'level' => 2,
-                'list' => [
-                    'one',
-                    'two',
-                ],
-                'hash' => [
-                    'one' => 1,
-                    'two' => 2,
-                ],
-                'null' => null,
-                'object' => stdClass::class,
-            ],
-        ];
-        $writer = new PhpArray();
-        $writer->toFile($this->file, $config);
-
-        $updated = $this->configResource->patchKey($key, $value);
-        $expected = ArrayUtils::merge($config, $expected);
-        $this->assertEquals($expected, $updated);
     }
 }


### PR DESCRIPTION
Per #28, the patch introduced in #25 and released with 1.3.1 breaks existing functionality as used by zf-apigility-admin.

This patch reverts the changes introduced in #25.