### PR TITLE
Sorted arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- The configuration that is written is now sorted by its keys.
+  This new feature is enabled by default. Sorting can be disabled by 
+  calling `->setSortingEnabled(false);`
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ service serves the purpose of providing the necessary dependencies for `ConfigRe
 methods such as `patch()` and `replace()`.  The service returned by the service manager is bound to
 the file specified in the `config_file` key.
 
+The config that is written is sorted by its keys. To disable this, use`setSortingEnabled` and provide 
+`false` as a parameter.
+
 #### ZF\Configuration\ConfigResourceFactory
 
 `ZF\Configuration\ConfigResourceFactory` is a factory service that provides consumers with the

--- a/src/ConfigResource.php
+++ b/src/ConfigResource.php
@@ -33,6 +33,13 @@ class ConfigResource
     protected $opcacheEnabled = false;
 
     /**
+     * Whether or not sorting of the config is enabled.
+     *
+     * @var bool
+     */
+    protected $sortingEnabled = true;
+
+    /**
      * @var ConfigWriter
      */
     protected $writer;
@@ -49,6 +56,16 @@ class ConfigResource
         $this->config   = $config;
         $this->fileName = $fileName;
         $this->writer   = $writer;
+    }
+
+    /**
+     * Enables or disables the sorting of the config data.
+     *
+     * @param bool $enabled
+     */
+    public function setSortingEnabled($enabled)
+    {
+        $this->sortingEnabled = $enabled;
     }
 
     /**
@@ -128,7 +145,9 @@ class ConfigResource
      */
     public function overWrite(array $data)
     {
-        $this->sortKeysRecursively($data);
+        if ($this->sortingEnabled) {
+            $this->sortKeysRecursively($data);
+        }
 
         $this->writer->toFile($this->fileName, $data);
 

--- a/test/ConfigResourceTest.php
+++ b/test/ConfigResourceTest.php
@@ -457,4 +457,25 @@ class ConfigResourceTest extends TestCase
         self::assertEquals('z', $secondKey);
         self::assertEquals('2', $secondVal);
     }
+
+    public function testDataIsNotSortedWhenDisabled()
+    {
+        // Arrange
+        $config = [
+            'z' => 1,
+            'a' => 2,
+        ];
+
+        $configResource = new ConfigResource($config, $this->file, new PhpArray());
+
+        // Act
+        $configResource->setSortingEnabled(false);
+        $configResource->overWrite($config);
+
+        // Assert
+        $test = include $this->file;
+
+        self::assertEquals(1, current($test));
+        self::assertEquals(2, next($test));
+    }
 }

--- a/test/ConfigResourceTest.php
+++ b/test/ConfigResourceTest.php
@@ -402,4 +402,59 @@ class ConfigResourceTest extends TestCase
         $test = include $this->file;
         $this->assertEquals($expected, $test);
     }
+
+    public function testDataIsSorted()
+    {
+        // Arrange
+        $config = [
+            'z' => 1,
+            'a' => 2,
+        ];
+
+        $configResource = new ConfigResource($config, $this->file, new PhpArray());
+
+        // Act
+        $configResource->overWrite($config);
+
+        // Assert
+        $test = include $this->file;
+
+        self::assertEquals(2, current($test));
+        self::assertEquals(1, next($test));
+    }
+
+    public function testDataIsSortedRecursively()
+    {
+        // Arrange
+        $config = [
+            'z' => [
+                'z' => 1,
+                'a' => 2,
+            ],
+            'a' => [
+                'z' => 1,
+                'a' => 2,
+            ],
+        ];
+
+        $configResource = new ConfigResource($config, $this->file, new PhpArray());
+
+        // Act
+        $configResource->overWrite($config);
+
+        // Assert
+        $test = include $this->file;
+
+        $firstKey = key($test);
+        $firstVal = current($test[$firstKey]);
+        self::assertEquals('a', $firstKey);
+        self::assertEquals('2', $firstVal);
+
+        next($test);
+
+        $secondKey = key($test);
+        $secondVal = current($test[$secondKey]);
+        self::assertEquals('z', $secondKey);
+        self::assertEquals('2', $secondVal);
+    }
 }


### PR DESCRIPTION
This is a new feature where the configuration written is sorted by its keys. This is useful in case of large configs so developers can expect where data is located in the file.

This new feature is enabled by default and can be turned off by calling `->setSortingEnabled(false);`.